### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./public
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ I built the following dashboard for my children to see what weekday and time of 
 
 ![Example dashboard](example.jpg)
 
+## Live Page
+
+The dashboard is automatically deployed from the `main` branch. You can view it at
+[https://<your-github-username>.github.io/kobo-dashboard/](https://<your-github-username>.github.io/kobo-dashboard/).
+
 ## Design
 
 ### Why so legacy technologies?


### PR DESCRIPTION
## Summary
- deploy `public/` folder to GitHub Pages on pushes to `main`
- document live page URL in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688120a460f083279609dbb64e21d8f8